### PR TITLE
FIX: Fixes #2 "Componentisation" of advanced asset features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,31 @@
 # SilverStripe Advanced Assets
 
 Provides an additional Files admin area in the CMS in parallel with the CMS' standard
-Files admin area, that allows for some more "advanced" file and folder options.
+Files admin area. It allows for some "advanced" file and folder features as follows:
 
 ## Features
 
- * Allows fine-grained access to files and folders using the CMS' standard security system
- * Allows individual access to the SecuredFiles CMS admin
- * Allows for embargo and expiry on individual files and folders
- * Integrates with the [Subsites module](http://addons.silverstripe.org/add-ons/silverstripe/subsites)
+ 1. Individual permissions to files and folders using the CMS' standard security system
+ 2. Embargo and expiry on individual files and folders
+ 3. Individual access to the Advanced Assets CMS admin
+ 4. Integrates with the [Subsites module](http://addons.silverstripe.org/add-ons/silverstripe/subsites)
+
+Note: 1. and 2. (above) need to be explicitly enabled. See the "Options" section below.
+
+## Compatibility
+
+If installed alongside the standard "Secured Files" module, the latter's features and access
+will be disabled.
+
+## Options
+
+The module's features have been broadly broken into 2 components; Embargo / Expiry and Security.
+Each of these components are able to be individually enabled or disabled via the standard SilverStripe
+YML configuration system and are _disabled_ by default. To enable them:
+
+    AdvancedAssetsFilesSiteConfig:
+      component_security_enabled: true
+      component_embargoexpiry_enabled: true
 
 ## Installation
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -25,7 +25,7 @@ LeftAndMain:
     - SecuredFilesLeftAndMain
 SiteConfig:
   extensions:
-    - AdvancedSecuredFilesSiteConfig
+    - AdvancedAssetsFilesSiteConfig
 DBField:
   extensions:
     - SecuredFileRichLinksExtension
@@ -35,3 +35,4 @@ Controller:
 HtmlEditorField_Toolbar:
   extensions:
     - SecuredFilesHtmlEditorField_Toolbar
+    

--- a/code/admin/SecuredAssetAdmin.php
+++ b/code/admin/SecuredAssetAdmin.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * 
- * Creates a new folder on the F/S for uploading assets to ina secure manner by:
+ * Creates a new folder on the F/S for uploading assets to, and in a secure manner by:
  * 
- * - Adding dynamically populate .htaccess and web.config files.
+ * - Adding dynamically populated .htaccess and web.config files.
  * - Use of canXX() methods on both child folders and files.
  * 
  * @author Deviate Ltd 2014-2015 http://www.deviate.net.nz
@@ -12,19 +12,56 @@
  * @todo Modify addFolder() and initValidate() to show messages within the CMS.
  */
 class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
-    
-    private static $url_segment = 'assets-secured';
+
+    /**
+     *
+     * @var string
+     */
+    private static $url_segment = 'advanced-assets';
+
+    /**
+     *
+     * @var string
+     */
     private static $url_rule = '/$Action/$ID';
-    private static $menu_title = 'Secured Files';
+
+    /**
+     *
+     * @var string
+     */
+    private static $menu_title = 'Advanced Files';
+
+    /**
+     *
+     * @var string
+     */
     private static $menu_icon = "silverstripe-advancedassets/resource/images/padlock-gray-16x16.png";
+
+    /**
+     *
+     * @var string
+     */
     private static $tree_class = 'Folder';
+
+    /**
+     *
+     * @var int
+     */
     private static $menu_priority = 5;
 
+    /**
+     *
+     * @var array
+     */
     private static $allowed_actions = array(
         "doSync",
         "addfolder",
     );
 
+    /**
+     * 
+     * @return void
+     */
     public function init() {
         self::instantiate();
         parent::init();
@@ -59,26 +96,22 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
      * @return void
      */
     public static function instantiate() {
-        $secured_root_folder = BASE_PATH . DIRECTORY_SEPARATOR .ASSETS_DIR . DIRECTORY_SEPARATOR . "_securedfiles";
+        $secured_root_folder = BASE_PATH . DIRECTORY_SEPARATOR . ASSETS_DIR . DIRECTORY_SEPARATOR . "_securedfiles";
         if(!is_dir($secured_root_folder)) {
-            FileSecured::find_or_make_secured("_securedfiles/Uploads" );
+            FileSecured::find_or_make_secured("_securedfiles/Uploads");
         }
-        
+
         $resource_folder = BASE_PATH . DIRECTORY_SEPARATOR . SECURED_FILES_MODULE_DIR . DIRECTORY_SEPARATOR . 'resource';
-        $default_lock_images_folder = BASE_PATH . DIRECTORY_SEPARATOR .ASSETS_DIR . DIRECTORY_SEPARATOR . '_defaultlockimages';
+        $default_lock_images_folder = BASE_PATH . DIRECTORY_SEPARATOR . ASSETS_DIR . DIRECTORY_SEPARATOR . '_defaultlockimages';
         if(!is_dir($default_lock_images_folder)) {
-            mkdir($default_lock_images_folder,
-                Config::inst()->get('Filesystem', 'folder_create_mask')
-            );
+            mkdir($default_lock_images_folder, Config::inst()->get('Filesystem', 'folder_create_mask'));
             $resource_images_folder = $resource_folder . DIRECTORY_SEPARATOR . 'images';
             $dir = dir($resource_images_folder);
             while(false !== $entry = $dir->read()) {
                 if($entry == '.' || $entry == '..') {
                     continue;
                 }
-                copy($resource_images_folder. DIRECTORY_SEPARATOR . $entry,
-                    $default_lock_images_folder . DIRECTORY_SEPARATOR . $entry
-                );
+                copy($resource_images_folder . DIRECTORY_SEPARATOR . $entry, $default_lock_images_folder . DIRECTORY_SEPARATOR . $entry);
             }
         }
 
@@ -104,7 +137,7 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
      * @return number
      */
     public function currentPageID() {
-        if(is_numeric($this->request->requestVar('ID')))	{
+        if(is_numeric($this->request->requestVar('ID'))) {
             return $this->request->requestVar('ID');
         } elseif(is_numeric($this->urlParams['ID'])) {
             return $this->urlParams['ID'];
@@ -124,27 +157,27 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
 
     /**
      * 
-     * @param mumber $id
+     * @param int $id
      * @param FieldList $fields
      * @return Form
      */
     public function getEditForm($id = null, $fields = null) {
-        if(!$id) $id=$this->currentPageID();
+        if(!$id)
+            $id = $this->currentPageID();
         $form = parent::getEditForm($id, $fields);
         $folder = ($id && is_numeric($id) && $id > 0) ? DataObject::get_by_id('Folder', $id, false) : $this->currentPage();
         $gridField = $form->Fields()->dataFieldByName('File');
-        $gridField->setTitle(_t("SECUREDASSETADMIN.SecuriedFiles", "Secured Files"));
+        $gridField->setTitle(_t("SECUREDASSETADMIN.SecuriedFiles", "Advanced Assets"));
         $config = $gridField->getConfig();
         $columns = $config->getComponentByType('GridFieldDataColumns');
         $displayFields = $columns->getDisplayFields($gridField);
         $displayFields = array_merge(
-            $displayFields,
-            array(
-                'WhoCanViewHTML'=> _t('SecuredAssetAdmin.WHOCANVIEW', 'Who can view?'),
-                'WhoCanEditHTML'=> _t('SecuredAssetAdmin.WHOCANEDIT', 'Who can edit?'),
-                'EmbargoHTML'   => _t('SecuredAssetAdmin.EmbargoingStatus', 'Embargoing Status'),
-                'ExpireHTML'    => _t('SecuredAssetAdmin.ExpiringStatus', 'Expiring Status'),
-            )
+                $displayFields, array(
+            'WhoCanViewHTML' => _t('SecuredAssetAdmin.WHOCANVIEW', 'Who can view?'),
+            'WhoCanEditHTML' => _t('SecuredAssetAdmin.WHOCANEDIT', 'Who can edit?'),
+            'EmbargoHTML' => _t('SecuredAssetAdmin.EmbargoingStatus', 'Embargoing Status'),
+            'ExpireHTML' => _t('SecuredAssetAdmin.ExpiringStatus', 'Expiring Status'),
+                )
         );
         $columns->setDisplayFields($displayFields);
 
@@ -157,30 +190,31 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
             $form->Fields()->removeByName("DetailsView");
             $config->removeComponentsByType("GridFieldLevelup");
         } else {
-            $config->getComponentByType("GridFieldLevelup")->setLinkSpec('admin/'.self::$url_segment.'/show/%d');
+            $config->getComponentByType("GridFieldLevelup")->setLinkSpec('admin/' . self::$url_segment . '/show/%d');
         }
 
-        $gridField->setTitle(_t("SECUREDASSETADMIN.SecuriedFiles", "Secured Files"));
+        $gridField->setTitle(_t("SECUREDASSETADMIN.SecuriedFiles", "Advanced Assets"));
         if($id == FileSecured::getSecuredRoot()->ID) {
             $form->Fields()->removeByName("DetailsView");
         }
-        
-        //need to use CMSSecuredFileAddController, so update the "Upload" button.
+
+        // Need to use CMSSecuredFileAddController, so update the "Upload" button.
         if($folder->canCreate()) {
             $uploadBtn = new LiteralField(
-                'UploadButton',
-                sprintf(
-                    '<a class="ss-ui-button ss-ui-action-constructive cms-panel-link" data-pjax-target="Content" data-icon="drive-upload" href="%s">%s</a>',
-                    Controller::join_links(singleton('CMSSecuredFileAddController')->Link(), '?ID=' . $folder->ID),
-                    _t('Folder.UploadFilesButton', 'Upload')
-                )
+                    'UploadButton', sprintf(
+                            '<a class="ss-ui-button ss-ui-action-constructive cms-panel-link"'
+                            . ' data-pjax-target="Content" data-icon="drive-upload"'
+                            . ' href="%s">%s</a>', 
+                            Controller::join_links(singleton('CMSSecuredFileAddController')->Link(), '?ID=' . $folder->ID), 
+                            _t('Folder.UploadFilesButton', 'Upload')
+                    )
             );
         } else {
             $uploadBtn = null;
         }
 
         foreach(array("ListView", "TreeView") as $viewName) {
-            $view = $form->Fields()->fieldByName("Root.".$viewName);
+            $view = $form->Fields()->fieldByName("Root." . $viewName);
             foreach($view->Fields() as $f) {
                 if($f instanceof CompositeField) {
                     foreach($f->FieldList() as $cf) {
@@ -190,12 +224,11 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
                                 $cf->insertBefore($uploadBtn, "AddFolderButton");
                             }
                         }
-
                     }
                 }
             }
         }
-        
+
         return $form;
     }
 
@@ -219,15 +252,15 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
         $items = new ArrayList();
         $i = 0;
         foreach($itemsDefault as $item) {
-            if($i!==0) {
+            if($i !== 0) {
                 $items->push($item);
             }
             $i++;
         }
         if(isset($items[0]->Title)) {
-            $items[0]->Title = _t("SECUREDASSETADMIN.SecuriedFiles", "Secured Files");
+            $items[0]->Title = _t("SECUREDASSETADMIN.SecuriedFiles", "Advanced Assets");
         }
-        
+
         return $items;
     }
 
@@ -258,7 +291,7 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
         $this->response->addHeader('X-Status', rawurlencode($message));
         return;
     }
-    
+
     /**
      * 
      * {@inheritdoc}
@@ -274,17 +307,17 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
                 $message = _t('SecuredFilesystem.messages.ERROR_ACCESS_ONLY_IN_FILES');
                 return SecuredFilesystem::show_access_message($this, $message);
             }
-            
+
             return parent::addfolder($request);
         } else {
             $message = _t('SecuredFilesystem.messages.ERROR_FOLDER_NOT_EXISTS');
             return SecuredFilesystem::show_access_message($this, $message);
-        }        
+        }
     }
-    
+
     /**
      * 
-     * Write web-server specific config files to the secured files, assets-sub directory.
+     * Write web-server specific config files to the module's files, assets-sub directory.
      * 
      * @param string $folderSec
      * @param string $folderRes
@@ -305,4 +338,5 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
             file_put_contents($folderSec . DIRECTORY_SEPARATOR . 'web.config', $webDotConfig->getValue());
         }
     }
+
 }

--- a/code/controllers/CMSSecuredFileAddController.php
+++ b/code/controllers/CMSSecuredFileAddController.php
@@ -10,7 +10,7 @@ class CMSSecuredFileAddController extends CMSFileAddController {
     private static $url_segment = 'assets-secured/add';
     private static $url_priority = 65;
     private static $required_permission_codes = 'CMS_ACCESS_SecuredAssetAdmin';
-    private static $menu_title = 'Secured Files';
+    private static $menu_title = 'Advanced Assets';
     private static $tree_class = 'Folder';
 
     public function init(){
@@ -130,7 +130,7 @@ class CMSSecuredFileAddController extends CMSFileAddController {
             $i++;
         }
         if(isset($items[0]->Title)){
-            $items[0]->Title = _t("SECUREDASSETADMIN.SecuriedFiles", "Secured Files");
+            $items[0]->Title = _t("SECUREDASSETADMIN.SecuriedFiles", "Advanced Assets");
         }
         return $items;
     }

--- a/code/extensions/AdvancedAssetsFilesSiteConfig.php
+++ b/code/extensions/AdvancedAssetsFilesSiteConfig.php
@@ -4,19 +4,93 @@
  * @author Deviate Ltd 2014-2015 http://www.deviate.net.nz
  * @package silverstripe-advancedassets
  */
-class AdvancedSecuredFilesSiteConfig extends DataExtension {
+class AdvancedAssetsFilesSiteConfig extends DataExtension {
     
+    /**
+     *
+     * @var array
+     */
     private static $db = array(
         "SecuredFileDefaultTitle"   => "Varchar",
         "SecuredFileDefaultContent" => "HTMLText",
     );
     
+    /**
+     *
+     * @var array
+     */
     private static $has_one = array(
         "LockpadImageNeedLogIn"     => "Image",
         "LockpadImageNoAccess"      => "Image",
         "LockpadImageNoLongerAvailable" => "Image",
         "LockpadImageNotYetAvailable"   => "Image",
     );
+    
+    /**
+     * 
+     * The module is comprised of advanced "components". This static provides us
+     * with an authoratative list of them.
+     * 
+     * @var array
+     */
+    private static $allowed_components = array(
+        'security',
+        'embargoexpiry',
+        'metadata'
+    );
+    
+    /**
+     * 
+     * Determine if a component is enabled or not. By default all components are disabled
+     * unless explicitly enabled by a developer in a project's YML config as follows:
+     * 
+     *    AdvancedAssetsFilesSiteConfig:
+     *      component_security_enabled: true
+     *      component_embargoexpiry_enabled: true
+     *      component_metadata_enabled: true
+     * 
+     * @param string $component
+     * @throws AdvancedAssetsException
+     * @return boolean
+     */
+    private static function is_component_enabled($component) {
+        $component = strtolower(trim($component));
+        if(!in_array($component, self::$allowed_components)) {
+            throw new AdvancedAssetsException('Component not allowed.');
+        }
+        
+        $componentKey = 'component_' . $component . '_enabled';
+        $setting = Config::inst()->get('AdvancedAssetsFilesSiteConfig', $componentKey);
+        if($setting !== null) {
+            return (bool)$setting;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * 
+     * @return boolean
+     */
+    public static function is_security_enabled() {
+        return self::is_component_enabled('security');
+    }
+    
+    /**
+     * 
+     * @return boolean
+     */
+    public static function is_metadata_enabled() {
+        return self::is_component_enabled('metadata');
+    }
+    
+    /**
+     * 
+     * @return boolean
+     */
+    public static function is_embargoexpiry_enabled() {
+        return self::is_component_enabled('embargoexpiry');
+    }
 
     /**
      * 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -2,5 +2,5 @@ en:
   SecuredFilesystem:
     messages:
       ERROR_ACCESS_ONLY_IN_FILES: 'This folder is only accessible via the "Files" admin.'
-      ERROR_ACCESS_ONLY_IN_SECURED_FILES: 'This folder is only accessible via the "Secured Files" admin.'
+      ERROR_ACCESS_ONLY_IN_SECURED_FILES: 'This folder is only accessible via the "Advanced Assets" admin.'
       ERROR_FOLDER_NOT_EXISTS: "The selected folder doesn't exist"

--- a/resource/webconfig.ss
+++ b/resource/webconfig.ss
@@ -4,7 +4,7 @@
         <rewrite>
             <rules>
                 <clear/>
-                <rule name="Secured Files Clean URL" stopProcessing="true">
+                <rule name="Advanced Assets Clean URL" stopProcessing="true">
                     <match url="^(.*)$" />
                     <conditions>
                         <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="false" />


### PR DESCRIPTION
- Allows YML config to toggle show/hide of advanced CMS features.
- Changed many instances of "Secured" text to "Advanced".
- Renamed AdvancedSecuredFilesSiteConfig to AdvancedAssetsFilesSiteConfig.
- Updated README.
