### PR TITLE
FIX: Fixes #12 Removes duplicate logic from sync routine.

### DIFF
--- a/code/admin/NonSecuredAssetAdmin.php
+++ b/code/admin/NonSecuredAssetAdmin.php
@@ -26,8 +26,7 @@ class NonSecuredAssetAdmin extends AssetAdmin {
      * @var array
      */
     private static $allowed_actions = array(
-        "doSync",
-        "addfolder",
+        "addfolder"
     );
 
     /**
@@ -90,19 +89,6 @@ class NonSecuredAssetAdmin extends AssetAdmin {
             $items[0]->Link = Controller::join_links(singleton('NonSecuredAssetAdmin')->Link('show'), 0);
         }
         return $items;
-    }
-    
-    /**
-     * Can be queried with an ajax request to trigger the filesystem sync. It returns a FormResponse status message
-     * to display in the CMS
-     * 
-     * @return null
-     */
-    public function doSync() {
-        $message = SecuredFilesystem::sync_secured();
-        $this->response->addHeader('X-Status', rawurlencode($message));
-
-        return;
     }
 
     /**

--- a/code/admin/SecuredAssetAdmin.php
+++ b/code/admin/SecuredAssetAdmin.php
@@ -54,8 +54,7 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
      * @var array
      */
     private static $allowed_actions = array(
-        "doSync",
-        "addfolder",
+        "addfolder"
     );
 
     /**
@@ -276,20 +275,6 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
                 'category' => _t('Permission.CMS_ACCESS_CATEGORY', 'CMS Access')
             )
         );
-    }
-
-    /**
-     * 
-     * Can be queried with an ajax request to trigger the filesystem sync. It returns a FormResponse status message
-     * to display in the CMS
-     * 
-     * @return null
-     */
-    public function doSync() {
-        $securedRoot = FileSecured::getSecuredRoot();
-        $message = SecuredFilesystem::sync_secured($securedRoot->ID);
-        $this->response->addHeader('X-Status', rawurlencode($message));
-        return;
     }
 
     /**

--- a/code/extensions/FileSecured.php
+++ b/code/extensions/FileSecured.php
@@ -393,11 +393,13 @@ class FileSecured extends DataExtension implements PermissionProvider {
     }
 
     /**
-     * 
+     * Gets us the module's root directory. Because this is created on-the-fly, then we can never accurately know
+     * its ID.
+     *
      * @return Folder
      */
     public static function getSecuredRoot() {
-        return $securedRoot = Folder::get_one("Folder", "\"ParentID\" = '0' AND \"Secured\" = '1'");
+        return DataObject::get_one("File", "\"ParentID\" = '0' AND \"Secured\" = '1'");
     }
 
     /**

--- a/code/extensions/FolderSecured.php
+++ b/code/extensions/FolderSecured.php
@@ -1,201 +1,77 @@
 <?php
 /**
  *
- * This extension only adds x2 customised methods for Folder object:
+ * This extension "augments" the CMS synchronisation logic to include SQL for "Secured = '0'" in specific circumstances.
  * 
- * {@link FolderSecured::securedSyncChildren()} is a customised version of {@link Folder::syncChildren()}
- * with two places of overwritten marked as @customised
- * {@Link FolderSecured::constructChildSecuredWithSecuredFlag is a customised version of
- * {@link Folder::constructChild()} which also populates the File's "Secured" field
- * 
- * @author Deviate Ltd 2014-2015 http://www.deviate.net.nz
+ * @author Deviate Ltd 2014-2015 <http://deviate.net.nz>
  * @package silverstripe-advancedassets
- * @todo How many of the "cloned" methods/props from {@link Folder} are actually neeed?
  */
 class FolderSecured extends DataExtension {
-    
+
     /**
-     * 
-     * "Secure" version of {@link Folder::SyncChildren}.
-     * 
-     * @return array
+     * Ensures there are no merges between a secured folder and non-secured folder.
+     * There is only one case that both secured child folder and non-secured child folders exist and that's when
+     * $this->owner is on assets root.
+     *
+     * @param SQLQuery $query
+     * @return void
      */
-    public function securedSyncChildren() {
-        $parentID = (int)$this->owner->ID; // parentID = 0 on the singleton, used as the 'root node';
-        $added = 0;
-        $deleted = 0;
-        $skipped = 0;
-
-        // First, merge any children that are duplicates
-        //customised
-        if($parentID === 0) {
-            //make sure there are no merges between a secured folder and non-secured folder.
-            //there is only one case that there are both secured child folder and non-secured child folder exists,
-            //that is when $this->owner is on assets root.
-            $duplicateChildrenNames = DB::query("SELECT \"Name\" FROM \"File\""
-                ." WHERE \"ParentID\"=$parentID AND \"Secured\"='0' GROUP BY \"Name\" HAVING count(*) > 1")->column();
-        } else {
-            $duplicateChildrenNames = DB::query("SELECT \"Name\" FROM \"File\""
-                . " WHERE \"ParentID\" = $parentID GROUP BY \"Name\" HAVING count(*) > 1")->column();
+    public function augmentSQL(SQLQuery &$query) {
+        $sql = $query->sql();
+        $rawQuery = str_replace(array('"', "'"), '', $sql);
+        $isDuplicateSql = stristr($rawQuery, "SELECT DISTINCT File.ClassName,") !== false;
+        $isStdFilesSyncReq = $this->isStandardFileSyncRequest();
+        if($isStdFilesSyncReq && $isDuplicateSql) {
+            $query->addWhere('"Secured" = \'0\'');
         }
-        
-        if($duplicateChildrenNames) {
-            foreach($duplicateChildrenNames as $childName) {
-                $childName = Convert::raw2sql($childName);
-                // Note, we do this in the database rather than object-model; otherwise we get all sorts of problems
-                // about deleting files
-                $children = DB::query("SELECT \"ID\" FROM \"File\""
-                    . " WHERE \"Name\" = '$childName' AND \"ParentID\" = $parentID")->column();
-                if($children) {
-                    $keptChild = array_shift($children);
-                    foreach($children as $removedChild) {
-                        DB::query("UPDATE \"File\" SET \"ParentID\" = $keptChild WHERE \"ParentID\" = $removedChild");
-                        DB::query("DELETE FROM \"File\" WHERE \"ID\" = $removedChild");
-                    }
-                } else {
-                    user_error("Inconsistent database issue: SELECT ID FROM \"File\" WHERE Name = '$childName'"
-                        . " AND ParentID = $parentID should have returned data", E_USER_WARNING);
-                }
-            }
-        }
-
-        // Get index of database content
-        // We don't use DataObject so that things like subsites doesn't muck with this.
-        $dbChildren = DB::query("SELECT * FROM \"File\" WHERE \"ParentID\" = $parentID");
-        $hasDbChild = array();
-
-        if($dbChildren) {
-            foreach($dbChildren as $dbChild) {
-                $className = $dbChild['ClassName'];
-                if(!$className) $className = "File";
-                $hasDbChild[$dbChild['Name']] = new $className($dbChild);
-            }
-        }
-        $unwantedDbChildren = $hasDbChild;
-
-        // if we're syncing a folder with no ID, we assume we're syncing the root assets folder
-        // however the Filename field is populated with "NewFolder", so we need to set this to empty
-        // to satisfy the baseDir variable below, which is the root folder to scan for new files in
-        if(!$parentID) {
-            $this->owner->Filename = '';
-        }
-
-        // Iterate through the actual children, correcting the database as necessary
-        $baseDir = $this->owner->FullPath;
-
-        // @todo this shouldn't call die() but log instead
-        if($parentID && !$this->owner->Filename) die($this->owner->ID . " - " . $this->owner->FullPath);
-
-        if(file_exists($baseDir)) {
-            $actualChildren = scandir($baseDir);
-            $ignoreRules = Config::inst()->get('Filesystem', 'sync_blacklisted_patterns');
-            foreach($actualChildren as $actualChild) {
-                if($ignoreRules) {
-                    $skip = false;
-
-                    foreach($ignoreRules as $rule) {
-                        if(preg_match($rule, $actualChild)) {
-                            $skip = true;
-                            break;
-                        }
-                    }
-
-                    if($skip) {
-                        $skipped++;
-                        continue;
-                    }
-                }
-
-                // A record with a bad class type doesn't deserve to exist. It must be purged!
-                if(isset($hasDbChild[$actualChild])) {
-                    $child = $hasDbChild[$actualChild];
-                    if(( !( $child instanceof Folder ) && is_dir($baseDir . $actualChild) )
-                        || (( $child instanceof Folder ) && !is_dir($baseDir . $actualChild)) ) {
-                        DB::query("DELETE FROM \"File\" WHERE \"ID\" = $child->ID");
-                        unset($hasDbChild[$actualChild]);
-                    }
-                }
-
-                if(isset($hasDbChild[$actualChild])) {
-                    $child = $hasDbChild[$actualChild];
-                    unset($unwantedDbChildren[$actualChild]);
-                } else {
-                    $added++;
-                    $childID = $this->constructChildSecuredWithSecuredFlag($actualChild);
-                    $child = DataObject::get_by_id("File", $childID);
-                }
-
-                if($child && is_dir($baseDir . $actualChild)) {
-                    //customised
-                    //when we synch on assets root
-                    //we don't want to sync the secured root folder SECURED_FILES_ASSET_SUBDIR
-                    //This is only the case where both secured child folder and non-secured child folder exist
-                    if($parentID === 0 && $child->ID === FileSecured::getSecuredRoot()->ID) {
-                        $skipped ++;
-                    } else {
-                        //customised
-                        //Of cause, we need to call this customised version recursively
-                        $childResult = $child->securedSyncChildren();
-                        $added += $childResult['added'];
-                        $deleted += $childResult['deleted'];
-                        $skipped += $childResult['skipped'];
-                    }
-
-                }
-
-                // Clean up the child record from memory after use. Important!
-                $child->destroy();
-                $child = null;
-            }
-
-            // Iterate through the unwanted children, removing them all
-            if(isset($unwantedDbChildren)) foreach($unwantedDbChildren as $unwantedDbChild) {
-                DB::query("DELETE FROM \"File\" WHERE \"ID\" = $unwantedDbChild->ID");
-                $deleted++;
-            }
-        } else {
-            DB::query("DELETE FROM \"File\" WHERE \"ID\" = $this->owner->ID");
-        }
-
-        return array(
-            'added' => $added,
-            'deleted' => $deleted,
-            'skipped' => $skipped
-        );
     }
 
     /**
-     * 
-     * @param string $name
-     * @return number
+     * This method hooks into the write that is performed by {@link Folder::constructChild()} which is
+     * called by the main {@link Folder::syncChildren()} method. This simply ensures that the correct value for
+     * the "File" table's "Secured" field is written-to.
+     *
+     * @param array $manipulation
+     * @return null|void
      */
-    public function constructChildSecuredWithSecuredFlag($name) {
-        // Determine the class name - File, Folder or Image
-        $baseDir = $this->owner->FullPath;
-        if(is_dir($baseDir . $name)) {
-            $className = "Folder";
-        } else {
-            $className = File::get_class_for_file_extension(pathinfo($name, PATHINFO_EXTENSION));
+    public function augmentWrite(&$manipulation) {
+        // Don't bother with remaining logic if the controller request is not a synchronisation request
+        $isStdFilesSyncReq = $this->isStandardFileSyncRequest();
+        if(!$isStdFilesSyncReq) {
+            return;
         }
 
-        $ownerID = 0;
-        if(Member::currentUser()) {
-            $ownerID = Member::currentUser()->ID;
+        $secured = $this->owner->Secured ? '1' : '0';
+        foreach($manipulation as $table => $details) {
+            if($table != 'File' || !isset($details['fields']['Secured'])) {
+                continue;
+            }
+
+            $details['fields']['Secured'] = $secured;
+
+            // Save back modifications to the manipulation
+            $manipulation[$table] = $details;
         }
-
-        $filename = Convert::raw2sql($this->owner->Filename . $name);
-        if($className == 'Folder' ) {
-            $filename .= '/';
-        }
-
-        $name = Convert::raw2sql($name);
-        $secured = $this->owner->Secured?'1':'0';
-
-        DB::query("INSERT INTO \"File\"
-			(\"ClassName\",\"ParentID\",\"OwnerID\",\"Name\",\"Filename\",\"Created\",\"LastEdited\",\"Title\",\"Secured\")
-			VALUES ('$className', ".$this->owner->ID.", $ownerID, '$name', '$filename', "
-            . DB::getConn()->now() . ',' . DB::getConn()->now() . ", '$name', '$secured')");
-
-        return DB::getGeneratedID("File");
     }
+
+    /**
+     * Ascertains whether the current request is an Admin AJAX request for the CMS' synchronisation logic
+     * from the CMS' standard "Files" admin section, to prevent "Secured" files from being synchronised at the root
+     * level.
+     *
+     * @return boolean
+     */
+    private function isStandardFileSyncRequest() {
+        $controller = Controller::curr();
+        $isSubclass = is_subclass_of($controller, 'LeftAndMain');
+        $isAjax = Director::is_ajax();
+        $isAssetsRoot = (int)$this->owner->ID == 0;
+        $isDoSync = false;
+        if($urlParts = explode('/', $controller->getRequest()->getURL())) {
+            $isDoSync = end($urlParts) === 'doSync' ? true : false;
+        }
+
+        return ($isSubclass && $isAjax && $isAssetsRoot && $isDoSync);
+    }
+
 }

--- a/code/filesystem/SecuredFilesystem.php
+++ b/code/filesystem/SecuredFilesystem.php
@@ -1,50 +1,11 @@
 <?php
 /**
- *
- * {@link SecuredFilesystem::sync_secured()} overwrite {@link Filesystem::sync()} in a way that a folder
- * syncs its children safely, i.e, don't sync any secured child folder when the folder is non-secured,
- * and vise-versa.
  * 
- * @author Deviate Ltd 2014-2015 http://www.deviate.net.nz
+ * @author Deviate Ltd 2014-2015 <http://deviate.net.nz>
  * @package silverstripe-advancedassets
- * @see {@link FolderSecured::securedSyncChildren()}
  * @todo Modify show_access_message() to show messages within the CMS.
  */
 class SecuredFilesystem extends Filesystem {
-    
-    /**
-     * 
-     * @param number $folderID
-     * @return string
-     */
-    public static function sync_secured($folderID = null) {
-        $folder = DataObject::get_by_id('Folder', (int) $folderID);
-        if(!($folder && $folder->exists())) {
-            $folder = singleton('Folder');
-        }
-        
-        $results = $folder->securedSyncChildren();
-        $finished = false;
-        while(!$finished) {
-            $orphans = DB::query("SELECT \"C\".\"ID\" FROM \"File\" AS \"C\"
-				LEFT JOIN \"File\" AS \"P\" ON \"C\".\"ParentID\" = \"P\".\"ID\"
-				WHERE \"P\".\"ID\" IS NULL AND \"C\".\"ParentID\" > 0");
-            $finished = true;
-            if($orphans) foreach($orphans as $orphan) {
-                $finished = false;
-                // Delete the database record but leave the filesystem alone
-                $file = DataObject::get_by_id("File", $orphan['ID']);
-                $file->deleteDatabaseOnly();
-                unset($file);
-            }
-        }
-        
-        return _t(
-            'Filesystem.SYNCRESULTS',
-            'Sync complete: {createdcount} items created, {deletedcount} items deleted',
-            array('createdcount' => (int)$results['added'], 'deletedcount' => (int)$results['deleted'])
-        );
-    }
     
     /**
      * 


### PR DESCRIPTION
- Makes use of augmentWrite() and augmentSQL() instead.
  FIX: getSecuredRoot() failed during sync.
