### PR TITLE
FIX: Fixes #15 Non ADMIN users unable to use "Files" admin

### DIFF
--- a/code/admin/NonSecuredAssetAdmin.php
+++ b/code/admin/NonSecuredAssetAdmin.php
@@ -7,7 +7,7 @@
  * @package silverstripe-advancedassets
  * @todo Modify addFolder() and initValidate() to show messages within the CMS.
  */
-class NonSecuredAssetAdmin extends AssetAdmin {
+class NonSecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
     
     /**
      *
@@ -22,19 +22,26 @@ class NonSecuredAssetAdmin extends AssetAdmin {
     private static $menu_icon = "silverstripe-advancedassets/images/icons/controller-non-secured-asset-admin-16.png";
 
     /**
+     * This is called "Files" too becuase it overrides the CMS's standard {@link AssetAdmin}.
+     *
+     * @var string
+     */
+    private static $menu_title = "Files";
+
+    /**
      *
      * @var array
      */
     private static $allowed_actions = array(
         "doSync",
-        "addfolder",
+        "addfolder"
     );
 
     /**
      * 
      * @return void
      */
-    public function init(){
+    public function init() {
         parent::init();
         $this->initValidate();
     }
@@ -63,10 +70,23 @@ class NonSecuredAssetAdmin extends AssetAdmin {
     }
 
     /**
+     * @return array
+     */
+    public function providePermissions() {
+        $title = _t('NonSecuredAssetAdmin.labels.CMS_PERMISSIONS_LABEL_FILES_ADVANCED', 'Files (Advanced)');
+        return array(
+            "CMS_ACCESS_NonSecuredAssetAdmin" => array(
+                'name' => _t('CMSMain.ACCESS', "Access to '{title}' section", array('title' => $title)),
+                'category' => _t('Permission.CMS_ACCESS_CATEGORY', 'CMS Access')
+            )
+        );
+    }
+
+    /**
      * 
      * @return SS_List
      */
-    public function getList(){
+    public function getList() {
         $list = parent::getList();
         $list = $list->exclude("Secured", "1");
         return $list;
@@ -81,7 +101,7 @@ class NonSecuredAssetAdmin extends AssetAdmin {
     }
 
     /**
-     * 
+     * @param boolean $unlinked
      * @return array
      */
     public function Breadcrumbs($unlinked = false) {

--- a/code/admin/SecuredAssetAdmin.php
+++ b/code/admin/SecuredAssetAdmin.php
@@ -133,6 +133,7 @@ class SecuredAssetAdmin extends AssetAdmin implements PermissionProvider {
     /**
      * 
      * Return fake-ID "root" if no ID is found (needed to upload files into the root-folder)
+     * If no ID is found, it is assumed no secured|advanced assets folder exists, and so it is created.
      * 
      * @return number
      */

--- a/code/extensions/FileSecured.php
+++ b/code/extensions/FileSecured.php
@@ -272,23 +272,30 @@ class FileSecured extends DataExtension implements PermissionProvider {
         if($member && Permission::checkMember($member, array("ADMIN", "SECURED_FILES_VIEW_ALL"))) {
             return true;
         }
-        
+
+        // Check for empty spec and Deny - erring
+        if(!$this->owner->CanViewType) {
+            return false;
+        }
+
         // check different CanViewType accordingly
-        if(!$this->owner->CanViewType || $this->owner->CanViewType == 'Anyone') { // check for empty spec
+        if($this->owner->CanViewType == 'Anyone') {
             return true;
         } else if($this->owner->CanViewType == "LoggedInUsers") {
             return $member && $member->exists();
         } else if($this->owner->CanViewType == "OnlyTheseUsers") {
             return $member && $member->exists() && $member->inGroups($this->owner->ViewerGroups());
         } else if($this->owner->CanViewType == "Inherit") {
-            $folder = Folder::get_by_id("Folder", $this->owner->ParentID);
-            if($folder && $folder->exists()) {
-                return $folder->canViewFrontByUser($member);
-            } else {
-                return true;
+            // Usually only a problem when running tests without explicitly setting a parent
+            if($this->owner->ParentID) {
+                $folder = Folder::get_by_id("Folder", $this->owner->ParentID);
+                if ($folder && $folder->exists()) {
+                    return $folder->canViewFrontByUser($member);
+                }
             }
         }
 
+        // Err on the side of caution - https://en.wiktionary.org/wiki/err#Etymology
         return false;
     }
 
@@ -345,7 +352,9 @@ class FileSecured extends DataExtension implements PermissionProvider {
      */
     public static function find_or_make_secured($folderPath) {
         // Create assets directory, if it is missing
-        if(!file_exists(ASSETS_PATH)) Filesystem::makeFolder(ASSETS_PATH);
+        if(!file_exists(ASSETS_PATH)) {
+            Filesystem::makeFolder(ASSETS_PATH);
+        }
 
         $folderPath = trim(Director::makeRelative($folderPath));
         // replace leading and trailing slashes
@@ -380,7 +389,8 @@ class FileSecured extends DataExtension implements PermissionProvider {
                 $item->write();
                 // when initial the secured root folder, set its CanViewType to be
                 if(!$parentID) {
-                    $item->CanViewType = "Anyone";
+                    $item->CanViewType = 'Anyone';
+                    $item->CanEditType = 'LoggedInUsers';
                 }
             }
             if(!file_exists($item->getFullPath())) {
@@ -397,7 +407,7 @@ class FileSecured extends DataExtension implements PermissionProvider {
      * @return Folder
      */
     public static function getSecuredRoot() {
-        return $securedRoot = Folder::get_one("Folder", "\"ParentID\" = '0' AND \"Secured\" = '1'");
+        return Folder::get_one("Folder", "\"ParentID\" = '0' AND \"Secured\" = '1'");
     }
 
     /**
@@ -429,7 +439,7 @@ class FileSecured extends DataExtension implements PermissionProvider {
         if($this->owner->CanViewType != 'OnlyTheseUsers') {
             $viewerGroups = $this->owner->ViewerGroups();
             if($viewerGroups && $viewerGroups->exists()) {
-                    $viewerGroups->removeAll();
+                $viewerGroups->removeAll();
             }
         }
         if($this->owner->CanEditType != 'OnlyTheseUsers') {

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -5,3 +5,6 @@ en:
       ERROR_ACCESS_ONLY_IN_SECURED_FILES: 'This folder is only accessible via the "Advanced Assets" admin.'
       ERROR_FOLDER_NOT_EXISTS: "The selected folder doesn't exist"
       ERROR_FOLDER_NO_ACCESS: "You don't have permission to access the selected folder."
+  NonSecuredAssetAdmin:
+    labels:
+      CMS_PERMISSIONS_LABEL_FILES_ADVANCED: "Files (Advanced)"

--- a/tests/fixtures/FileSecuredTest.yml
+++ b/tests/fixtures/FileSecuredTest.yml
@@ -1,34 +1,50 @@
 # Test Members+Groups
+Group:
+  can-view-is-admin:
+    Title: 'We see all'
+  can-view-secured-asset-admin:
+    Title: 'We see some only within the secured asset admin'
+  can-view-secure-assets-in-frontend:
+    Title: 'We see all secured assets in the frontend'
+  can-view-standard-asset-admin-only:
+    Title: 'We see all non-secured assets in the standard asset admin'
+
 Member:
-  can-view-secured-files:
+  can-view-is-admin:
     FirstName: Big
     Surname: 'Bad Wolf'
     Email: big.bad.wolf@munchgranny.nz
     Password: test
-  can-view-unsecured-files-only:
+    Groups: =>Group.can-view-is-admin
+  can-view-secured-asset-admin:
     FirstName: Big
-    Surname: 'Friendly Giant'
-    Email: bfg@largehumanoid.nz
+    Surname: 'Bad Wolf'
+    Email: big.good.wolf@munchgranny.nz
     Password: test
-    
-Group:
-  can-view:
-    Code: can-view
-    Members: =>Member.can-view-secured-files
-  cannot-view:
-    Code: cannot-view
-    Members: =>Member.can-view-unsecured-files-only
+    Groups: =>Group.can-view-secured-asset-admin
+  can-view-standard-asset-admin-only:
+    FirstName: Big
+    Surname: 'Bad Wolf'
+    Email: big.good.bunny@munchgranny.nz
+    Password: test
+    Groups: =>Group.can-view-standard-asset-admin-only
+  can-view-secure-assets-in-frontend:
+    FirstName: Small
+    Surname: 'Sad Wolf'
+    Email: small.sad.wolf@lovesgranny.nz
+    Password: test
+    Groups: =>Group.can-view-secure-assets-in-frontend
     
 Permission:
-  secured-01:
+  can-view-is-admin:
     Code: ADMIN
-    Group: =>Group.can-view
-  secured-02:
+    GroupID: =>Group.can-view-is-admin
+  can-view-secured-asset-admin:
     Code: CMS_ACCESS_SecuredAssetAdmin
-    Group: =>Group.can-view
-  secured-02:
+    GroupID: =>Group.can-view-secured-asset-admin
+  can-view-secure-assets-in-frontend:
     Code: SECURED_FILES_VIEW_ALL
-    Group: =>Group.can-view
-  not-secured-01:
+    GroupID: =>Group.can-view-secure-assets-in-frontend
+  can-view-standard-asset-admin-only:
     Code: CMS_ACCESS_AssetAdmin
-    Group: =>Group.cannot-view
+    GroupID: =>Group.can-view-standard-asset-admin-only


### PR DESCRIPTION
- Tightened security on root assets folder.
- Completely refactored unit-tests for consistency and to increase coverage.
- Boyscouting phpdoc and newlines.
